### PR TITLE
Fix app lookup when ran in renderer process

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,8 @@
 
 const _ = require('lodash');
 const path = require('path');
-const app = require('electron').app;
+const electron = require('electron');
+const app = electron.app || electron.remote.app;
 const userData = app.getPath('userData');
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "electron-mocha --recursive tests -R progress",
+    "test": "electron-mocha --recursive tests -R progress && electron-mocha --renderer --recursive tests -R progress",
     "lint": "jshint --config .jshintrc --reporter unix lib tests",
     "readme": "jsdoc2md --template doc/README.hbs lib/storage.js > README.md"
   },


### PR DESCRIPTION
`electron.app` doesn't exist when requiring directly from the renderer
process (without `remote`). The correct way to refer to `app` in this
context is `electron.remote.app`.

This commit fixes the issue, as well as runs the whole test suite from
the renderer process too, which revealed the issue.

Partly fixes: https://github.com/jviotti/electron-json-storage/issues/5