### PR TITLE
When callbacks are provided, do not return promises as well

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -34,6 +34,13 @@ const rimraf = Bluebird.promisify(require('rimraf'));
 const path = require('path');
 const utils = require('./utils');
 
+function coalesceReturn(callback, promise) {
+  if (typeof callback === 'function') {
+    return;
+  }
+  return promise;
+}
+
 /**
  * @summary Read user data
  * @function
@@ -69,7 +76,7 @@ const utils = require('./utils');
  * });
  */
 exports.get = function(key, callback) {
-  return Bluebird.try(function() {
+  var promise = Bluebird.try(function() {
     const fileName = utils.getFileName(key);
     return fs.readFileAsync(fileName, { encoding: 'utf8' });
   }).catch(function(error) {
@@ -85,6 +92,8 @@ exports.get = function(key, callback) {
       throw new Error('Invalid data');
     }
   }).nodeify(callback);
+
+  return coalesceReturn(callback, promise);
 };
 
 /**
@@ -109,7 +118,7 @@ exports.get = function(key, callback) {
  * });
  */
 exports.set = function(key, json, callback) {
-  return Bluebird.try(function() {
+  var promise = Bluebird.try(function() {
     const fileName = utils.getFileName(key);
     const data = JSON.stringify(json);
 
@@ -119,6 +128,8 @@ exports.set = function(key, json, callback) {
 
     return fs.writeFileAsync(fileName, data);
   }).nodeify(callback);
+
+  return coalesceReturn(callback, promise);
 };
 
 /**
@@ -151,7 +162,7 @@ exports.set = function(key, json, callback) {
  * });
  */
 exports.has = function(key, callback) {
-  return Bluebird.try(function() {
+  var promise = Bluebird.try(function() {
     const fileName = utils.getFileName(key);
     return fs.statAsync(fileName).return(true);
   }).catch(function(error) {
@@ -161,6 +172,8 @@ exports.has = function(key, callback) {
 
     throw error;
   }).nodeify(callback);
+
+  return coalesceReturn(callback, promise);
 };
 
 /**
@@ -193,9 +206,11 @@ exports.has = function(key, callback) {
  */
 exports.keys = function(callback) {
   const userData = utils.getUserDataPath();
-  return fs.readdirAsync(userData).map(function(key) {
+  var promise = fs.readdirAsync(userData).map(function(key) {
     return path.basename(key, '.json');
   }).nodeify(callback);
+
+  return coalesceReturn(callback, promise);
 };
 
 /**
@@ -223,10 +238,12 @@ exports.keys = function(callback) {
  * });
  */
 exports.remove = function(key, callback) {
-  return Bluebird.try(function() {
+  var promise = Bluebird.try(function() {
     const fileName = utils.getFileName(key);
     return rimraf(fileName);
   }).nodeify(callback);
+
+  return coalesceReturn(callback, promise);
 };
 
 /**
@@ -251,5 +268,6 @@ exports.remove = function(key, callback) {
 exports.clear = function(callback) {
   const userData = utils.getUserDataPath();
   const jsonFiles = path.join(userData, '*.json');
-  return rimraf(jsonFiles).nodeify(callback);
+  var promise = rimraf(jsonFiles).nodeify(callback);
+  return coalesceReturn(callback, promise);
 };


### PR DESCRIPTION
Fixes #5 

Consumers of this electorn-json-storage can either use the promises that are returned, or provide a callback, which results in no return.