### PR TITLE
Drop promises support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,8 +19,6 @@
     // @author http://michael.haschke.biz/
     // @license http://unlicense.org/
 
-    "esversion"     : 6,
-
     // == Enforcing Options ===============================================
     //
     // These options tell JSHint to be more strict towards your code. Use

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ electron-json-storage
 [![Build Status](https://travis-ci.org/jviotti/electron-json-storage.svg?branch=master)](https://travis-ci.org/jviotti/electron-json-storage)
 [![Build status](https://ci.appveyor.com/api/projects/status/j9k3k7mgraardwvd/branch/master?svg=true)](https://ci.appveyor.com/project/jviotti/electron-json-storage/branch/master)
 
-[Electron](http://electron.atom.io) lacks an easy way to persist and read user settings for your application. `electron-json-storage` implements an API with promises and callback support somehow similar to [localStorage](https://developer.mozilla.org/en/docs/Web/API/Window/localStorage) to write and read JSON objects to/from the operating system application data directory, as defined by `app.getPath('userData')`.
+[Electron](http://electron.atom.io) lacks an easy way to persist and read user settings for your application. `electron-json-storage` implements an API somehow similar to [localStorage](https://developer.mozilla.org/en/docs/Web/API/Window/localStorage) to write and read JSON objects to/from the operating system application data directory, as defined by `app.getPath('userData')`.
 
 Installation
 ------------
@@ -34,15 +34,15 @@ Documentation
 
 
 * [storage](#module_storage)
-    * [.get(key)](#module_storage.get) ⇒ <code>Promise</code>
-    * [.set(key, json)](#module_storage.set) ⇒ <code>Promise</code>
-    * [.has(key)](#module_storage.has) ⇒ <code>Promise</code>
-    * [.keys()](#module_storage.keys) ⇒ <code>Promise</code>
-    * [.remove(key)](#module_storage.remove) ⇒ <code>Promise</code>
-    * [.clear()](#module_storage.clear) ⇒ <code>Promise</code>
+    * [.get(key, callback)](#module_storage.get)
+    * [.set(key, json, callback)](#module_storage.set)
+    * [.has(key, callback)](#module_storage.has)
+    * [.keys(callback)](#module_storage.keys)
+    * [.remove(key, callback)](#module_storage.remove)
+    * [.clear(callback)](#module_storage.clear)
 
 <a name="module_storage.get"></a>
-### storage.get(key) ⇒ <code>Promise</code>
+### storage.get(key, callback)
 If the key doesn't exist in the user data, an empty object is returned.
 Also notice that the `.json` extension is added automatically, but it's
 ignored if you pass it yourself.
@@ -54,20 +54,12 @@ called `foo.data.json`.
 **Kind**: static method of <code>[storage](#module_storage)</code>  
 **Summary**: Read user data  
 **Access:** public  
-**Fulfil**: <code>Object</code> - contents  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | key | <code>String</code> | key |
+| callback | <code>function</code> | callback (error, data) |
 
-**Example**  
-```js
-const storage = require('electron-json-storage');
-
-storage.get('foobar').then(function(data) {
-  console.log(data);
-});
-```
 **Example**  
 ```js
 const storage = require('electron-json-storage');
@@ -79,7 +71,7 @@ storage.get('foobar', function(error, data) {
 });
 ```
 <a name="module_storage.set"></a>
-### storage.set(key, json) ⇒ <code>Promise</code>
+### storage.set(key, json, callback)
 **Kind**: static method of <code>[storage](#module_storage)</code>  
 **Summary**: Write user data  
 **Access:** public  
@@ -88,13 +80,8 @@ storage.get('foobar', function(error, data) {
 | --- | --- | --- |
 | key | <code>String</code> | key |
 | json | <code>Object</code> | json object |
+| callback | <code>function</code> | callback (error) |
 
-**Example**  
-```js
-const storage = require('electron-json-storage');
-
-storage.set('foobar', { foo: 'bar' });
-```
 **Example**  
 ```js
 const storage = require('electron-json-storage');
@@ -104,31 +91,21 @@ storage.set('foobar', { foo: 'bar' }, function(error) {
 });
 ```
 <a name="module_storage.has"></a>
-### storage.has(key) ⇒ <code>Promise</code>
+### storage.has(key, callback)
 **Kind**: static method of <code>[storage](#module_storage)</code>  
 **Summary**: Check if a key exists  
 **Access:** public  
-**Fulfil**: <code>Boolean</code> - whether the key exists  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | key | <code>String</code> | key |
+| callback | <code>function</code> | callback (error, hasKey) |
 
 **Example**  
 ```js
 const storage = require('electron-json-storage');
 
-storage.has('foobar').then(function(hasKey) {
-  if (hasKey) {
-    console.log('There is data stored as `foobar`');
-  }
-});
-```
-**Example**  
-```js
-const storage = require('electron-json-storage');
-
-storage.has('foobar', function(error, data) {
+storage.has('foobar', function(error, hasKey) {
   if (error) throw error;
 
   if (hasKey) {
@@ -137,21 +114,15 @@ storage.has('foobar', function(error, data) {
 });
 ```
 <a name="module_storage.keys"></a>
-### storage.keys() ⇒ <code>Promise</code>
+### storage.keys(callback)
 **Kind**: static method of <code>[storage](#module_storage)</code>  
 **Summary**: Get the list of saved keys  
 **Access:** public  
-**Fulfil**: <code>String[]</code> - saved keys  
-**Example**  
-```js
-const storage = require('electron-json-storage');
 
-storage.keys().then(function(keys) {
-  for (var key of keys) {
-    console.log('There is a key called: ' + key);
-  }
-});
-```
+| Param | Type | Description |
+| --- | --- | --- |
+| callback | <code>function</code> | callback (error, keys) |
+
 **Example**  
 ```js
 const storage = require('electron-json-storage');
@@ -165,7 +136,7 @@ storage.keys(function(error, keys) {
 });
 ```
 <a name="module_storage.remove"></a>
-### storage.remove(key) ⇒ <code>Promise</code>
+### storage.remove(key, callback)
 Notice this function does nothing, nor throws any error
 if the key doesn't exist.
 
@@ -176,13 +147,8 @@ if the key doesn't exist.
 | Param | Type | Description |
 | --- | --- | --- |
 | key | <code>String</code> | key |
+| callback | <code>function</code> | callback (error) |
 
-**Example**  
-```js
-const storage = require('electron-json-storage');
-
-storage.remove('foobar');
-```
 **Example**  
 ```js
 const storage = require('electron-json-storage');
@@ -192,16 +158,15 @@ storage.remove('foobar', function(error) {
 });
 ```
 <a name="module_storage.clear"></a>
-### storage.clear() ⇒ <code>Promise</code>
+### storage.clear(callback)
 **Kind**: static method of <code>[storage](#module_storage)</code>  
 **Summary**: Clear all stored data  
 **Access:** public  
-**Example**  
-```js
-const storage = require('electron-json-storage');
 
-storage.clear();
-```
+| Param | Type | Description |
+| --- | --- | --- |
+| callback | <code>function</code> | callback (error) |
+
 **Example**  
 ```js
 const storage = require('electron-json-storage');

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -8,7 +8,7 @@ electron-json-storage
 [![Build Status](https://travis-ci.org/jviotti/electron-json-storage.svg?branch=master)](https://travis-ci.org/jviotti/electron-json-storage)
 [![Build status](https://ci.appveyor.com/api/projects/status/j9k3k7mgraardwvd/branch/master?svg=true)](https://ci.appveyor.com/project/jviotti/electron-json-storage/branch/master)
 
-[Electron](http://electron.atom.io) lacks an easy way to persist and read user settings for your application. `electron-json-storage` implements an API with promises and callback support somehow similar to [localStorage](https://developer.mozilla.org/en/docs/Web/API/Window/localStorage) to write and read JSON objects to/from the operating system application data directory, as defined by `app.getPath('userData')`.
+[Electron](http://electron.atom.io) lacks an easy way to persist and read user settings for your application. `electron-json-storage` implements an API somehow similar to [localStorage](https://developer.mozilla.org/en/docs/Web/API/Window/localStorage) to write and read JSON objects to/from the operating system application data directory, as defined by `app.getPath('userData')`.
 
 Installation
 ------------

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -29,9 +29,10 @@
  */
 
 const _ = require('lodash');
-const Bluebird = require('bluebird');
-const fs = Bluebird.promisifyAll(require('fs'));
-const rimraf = Bluebird.promisify(require('rimraf'));
+const async = require('async');
+const fs = require('fs');
+const exists = require('exists-file');
+const rimraf = require('rimraf');
 const path = require('path');
 const utils = require('./utils');
 
@@ -50,15 +51,7 @@ const utils = require('./utils');
  * called `foo.data.json`.
  *
  * @param {String} key - key
- * @fulfil {Object} - contents
- * @returns {Promise}
- *
- * @example
- * const storage = require('electron-json-storage');
- *
- * storage.get('foobar').then(function(data) {
- *   console.log(data);
- * });
+ * @param {Function} callback - callback (error, data)
  *
  * @example
  * const storage = require('electron-json-storage');
@@ -70,22 +63,31 @@ const utils = require('./utils');
  * });
  */
 exports.get = function(key, callback) {
-  return Bluebird.try(function() {
-    const fileName = utils.getFileName(key);
-    return fs.readFileAsync(fileName, { encoding: 'utf8' });
-  }).catch(function(error) {
-    if (error.code === 'ENOENT') {
-      return JSON.stringify({});
-    }
+  async.waterfall([
+    async.asyncify(_.partial(utils.getFileName, key)),
+    function(fileName, callback) {
+      fs.readFile(fileName, {
+        encoding: 'utf8'
+      }, function(error, object) {
+        if (!error) {
+          return callback(null, object);
+        }
 
-    throw error;
-  }).then(function(object) {
-    try {
-      return JSON.parse(object);
-    } catch (error) {
-      throw new Error('Invalid data');
+        if (error.code === 'ENOENT') {
+          return callback(null, JSON.stringify({}));
+        }
+
+        return callback(error);
+      });
+    },
+    function(object, callback) {
+      try {
+        callback(null, JSON.parse(object));
+      } catch (error) {
+        callback(new Error('Invalid data'));
+      }
     }
-  }).nodeify(callback);
+  ], callback);
 };
 
 /**
@@ -95,12 +97,7 @@ exports.get = function(key, callback) {
  *
  * @param {String} key - key
  * @param {Object} json - json object
- * @returns {Promise}
- *
- * @example
- * const storage = require('electron-json-storage');
- *
- * storage.set('foobar', { foo: 'bar' });
+ * @param {Function} callback - callback (error)
  *
  * @example
  * const storage = require('electron-json-storage');
@@ -110,16 +107,18 @@ exports.get = function(key, callback) {
  * });
  */
 exports.set = function(key, json, callback) {
-  return Bluebird.try(function() {
-    const fileName = utils.getFileName(key);
-    const data = JSON.stringify(json);
+  async.waterfall([
+    async.asyncify(_.partial(utils.getFileName, key)),
+    function(fileName, callback) {
+      const data = JSON.stringify(json);
 
-    if (!data) {
-      throw new Error('Invalid JSON data');
+      if (!data) {
+        return callback(new Error('Invalid JSON data'));
+      }
+
+      fs.writeFile(fileName, data, callback);
     }
-
-    return fs.writeFileAsync(fileName, data);
-  }).nodeify(callback);
+  ], callback);
 };
 
 /**
@@ -128,22 +127,12 @@ exports.set = function(key, json, callback) {
  * @public
  *
  * @param {String} key - key
- * @fulfil {Boolean} - whether the key exists
- * @returns {Promise}
+ * @param {Function} callback - callback (error, hasKey)
  *
  * @example
  * const storage = require('electron-json-storage');
  *
- * storage.has('foobar').then(function(hasKey) {
- *   if (hasKey) {
- *     console.log('There is data stored as `foobar`');
- *   }
- * });
- *
- * @example
- * const storage = require('electron-json-storage');
- *
- * storage.has('foobar', function(error, data) {
+ * storage.has('foobar', function(error, hasKey) {
  *   if (error) throw error;
  *
  *   if (hasKey) {
@@ -152,16 +141,10 @@ exports.set = function(key, json, callback) {
  * });
  */
 exports.has = function(key, callback) {
-  return Bluebird.try(function() {
-    const fileName = utils.getFileName(key);
-    return fs.statAsync(fileName).return(true);
-  }).catch(function(error) {
-    if (error.code === 'ENOENT') {
-      return false;
-    }
-
-    throw error;
-  }).nodeify(callback);
+  async.waterfall([
+    async.asyncify(_.partial(utils.getFileName, key)),
+    exists
+  ], callback);
 };
 
 /**
@@ -169,17 +152,7 @@ exports.has = function(key, callback) {
  * @function
  * @public
  *
- * @fulfil {String[]} - saved keys
- * @returns {Promise}
- *
- * @example
- * const storage = require('electron-json-storage');
- *
- * storage.keys().then(function(keys) {
- *   for (var key of keys) {
- *     console.log('There is a key called: ' + key);
- *   }
- * });
+ * @param {Function} callback - callback (error, keys)
  *
  * @example
  * const storage = require('electron-json-storage');
@@ -193,12 +166,20 @@ exports.has = function(key, callback) {
  * });
  */
 exports.keys = function(callback) {
-  const userData = utils.getUserDataPath();
-  return fs.readdirAsync(userData).filter(function(key) {
-    return !_.includes([ 'GPUCache' ], key);
-  }).map(function(key) {
-    return path.basename(key, '.json');
-  }).nodeify(callback);
+  async.waterfall([
+    async.asyncify(utils.getUserDataPath),
+    fs.readdir,
+    function(keys, callback) {
+      callback(null, _.chain(keys)
+        .reject(function(key) {
+          return _.includes([ 'GPUCache' ], key);
+        })
+        .map(function(key) {
+          return path.basename(key, '.json');
+        })
+        .value());
+    }
+  ], callback);
 };
 
 /**
@@ -211,12 +192,7 @@ exports.keys = function(callback) {
  * if the key doesn't exist.
  *
  * @param {String} key - key
- * @returns {Promise}
- *
- * @example
- * const storage = require('electron-json-storage');
- *
- * storage.remove('foobar');
+ * @param {Function} callback - callback (error)
  *
  * @example
  * const storage = require('electron-json-storage');
@@ -226,10 +202,10 @@ exports.keys = function(callback) {
  * });
  */
 exports.remove = function(key, callback) {
-  return Bluebird.try(function() {
-    const fileName = utils.getFileName(key);
-    return rimraf(fileName);
-  }).nodeify(callback);
+  async.waterfall([
+    async.asyncify(_.partial(utils.getFileName, key)),
+    rimraf
+  ], callback);
 };
 
 /**
@@ -237,12 +213,7 @@ exports.remove = function(key, callback) {
  * @function
  * @public
  *
- * @returns {Promise}
- *
- * @example
- * const storage = require('electron-json-storage');
- *
- * storage.clear();
+ * @param {Function} callback - callback (error)
  *
  * @example
  * const storage = require('electron-json-storage');
@@ -254,5 +225,5 @@ exports.remove = function(key, callback) {
 exports.clear = function(callback) {
   const userData = utils.getUserDataPath();
   const jsonFiles = path.join(userData, '*.json');
-  return rimraf(jsonFiles).nodeify(callback);
+  rimraf(jsonFiles, callback);
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "mochainon": "^1.0.0"
   },
   "dependencies": {
-    "bluebird": "^3.1.4",
+    "async": "^1.5.2",
+    "exists-file": "^1.0.0",
     "lodash": "^4.0.1",
     "rimraf": "^2.5.1"
   }

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -26,8 +26,7 @@
 
 const m = require('mochainon');
 const _ = require('lodash');
-const Bluebird = require('bluebird');
-const fs = Bluebird.promisifyAll(require('fs'));
+const fs = require('fs');
 const storage = require('../lib/storage');
 const utils = require('../lib/utils');
 
@@ -38,19 +37,31 @@ describe('Electron JSON Storage', function() {
 
   describe('.get()', function() {
 
-    it('should be rejected if no key', function() {
-      const promise = storage.get();
-      m.chai.expect(promise).to.be.rejectedWith('Missing key');
+    it('should yield an error if no key', function(done) {
+      storage.get(null, function(error, data) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Missing key');
+        m.chai.expect(data).to.not.exist;
+        done();
+      });
     });
 
-    it('should be rejected if key is not a string', function() {
-      const promise = storage.get(123);
-      m.chai.expect(promise).to.be.rejectedWith('Invalid key');
+    it('should yield an error if key is not a string', function(done) {
+      storage.get(123, function(error, data) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Invalid key');
+        m.chai.expect(data).to.not.exist;
+        done();
+      });
     });
 
-    it('should be rejected if key is a blank string', function() {
-      const promise = storage.get('    ');
-      m.chai.expect(promise).to.be.rejectedWith('Invalid key');
+    it('should yield an error if key is a blank string', function(done) {
+      storage.get('    ', function(error, data) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Invalid key');
+        m.chai.expect(data).to.not.exist;
+        done();
+      });
     });
 
     describe('given stored settings', function() {
@@ -59,19 +70,28 @@ describe('Electron JSON Storage', function() {
         storage.set('foo', { data: 'hello world' }, done);
       });
 
-      it('should eventually become the data', function() {
-        const promise = storage.get('foo');
-        m.chai.expect(promise).to.become({ data: 'hello world' });
+      it('should yield the data', function(done) {
+        storage.get('foo', function(error, data) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(data).to.deep.equal({ data: 'hello world' });
+          done();
+        });
       });
 
-      it('should eventually become the data if explicitly passing the extension', function() {
-        const promise = storage.get('foo.json');
-        m.chai.expect(promise).to.become({ data: 'hello world' });
+      it('should yield the data if explicitly passing the extension', function(done) {
+        storage.get('foo.json', function(error, data) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(data).to.deep.equal({ data: 'hello world' });
+          done();
+        });
       });
 
-      it('should eventually become an empty object given an incorrect key', function() {
-        const promise = storage.get('foobarbaz');
-        m.chai.expect(promise).to.become({});
+      it('should yield an empty object given an incorrect key', function(done) {
+        storage.get('foobarbaz', function(error, data) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(data).to.deep.equal({});
+          done();
+        });
       });
 
     });
@@ -88,9 +108,13 @@ describe('Electron JSON Storage', function() {
 
       });
 
-      it('should be rejected with an error', function() {
-        const promise = storage.get('foo');
-        m.chai.expect(promise).to.be.rejectedWith('Invalid data');
+      it('should yield an error with an error', function(done) {
+        storage.get('foo', function(error, data) {
+          m.chai.expect(error).to.be.an.instanceof(Error);
+          m.chai.expect(error.message).to.equal('Invalid data');
+          m.chai.expect(data).to.not.exist;
+          done();
+        });
       });
 
     });
@@ -99,40 +123,60 @@ describe('Electron JSON Storage', function() {
 
   describe('.set()', function() {
 
-    it('should be rejected if no key', function() {
-      const promise = storage.set(null, { foo: 'bar' });
-      m.chai.expect(promise).to.be.rejectedWith('Missing key');
+    it('should yield an error if no key', function(done) {
+      storage.set(null, { foo: 'bar' }, function(error) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Missing key');
+        done();
+      });
     });
 
-    it('should be rejected if key is not a string', function() {
-      const promise = storage.set(123, { foo: 'bar' });
-      m.chai.expect(promise).to.be.rejectedWith('Invalid key');
+    it('should yield an error if key is not a string', function(done) {
+      storage.set(123, { foo: 'bar' }, function(error) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Invalid key');
+        done();
+      });
     });
 
-    it('should be rejected if key is a blank string', function() {
-      const promise = storage.set('    ', { foo: 'bar' });
-      m.chai.expect(promise).to.be.rejectedWith('Invalid key');
+    it('should yield an error if key is a blank string', function(done) {
+      storage.set('    ', { foo: 'bar' }, function(error) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Invalid key');
+        done();
+      });
     });
 
-    it('should be rejected if data is not a valid JSON object', function() {
-      const promise = storage.set('foo', _.noop);
-      m.chai.expect(promise).to.be.rejectedWith('Invalid JSON data');
+    it('should yield an error if data is not a valid JSON object', function(done) {
+      storage.set('foo', _.noop, function(error) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Invalid JSON data');
+        done();
+      });
     });
 
     it('should be able to store a valid JSON object', function(done) {
-      storage.set('foo', { foo: 'baz' }).then(function() {
-        return storage.get('foo');
-      }).then(function(data) {
-        m.chai.expect(data).to.deep.equal({ foo: 'baz' });
-      }).nodeify(done);
+      storage.set('foo', { foo: 'baz' }, function(error) {
+        m.chai.expect(error).to.not.exist;
+
+        storage.get('foo', function(error, data) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(data).to.deep.equal({ foo: 'baz' });
+          done();
+        });
+      });
     });
 
     it('should ignore an explicit json extension', function(done) {
-      storage.set('foo.json', { foo: 'baz' }).then(function() {
-        return storage.get('foo');
-      }).then(function(data) {
-        m.chai.expect(data).to.deep.equal({ foo: 'baz' });
-      }).nodeify(done);
+      storage.set('foo.json', { foo: 'baz' }, function(error) {
+        m.chai.expect(error).to.not.exist;
+
+        storage.get('foo', function(error, data) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(data).to.deep.equal({ foo: 'baz' });
+          done();
+        });
+      });
     });
 
     describe('given an existing stored key', function() {
@@ -142,23 +186,32 @@ describe('Electron JSON Storage', function() {
       });
 
       it('should be able to override the stored key', function(done) {
-        storage.get('foo').then(function(data) {
+        storage.get('foo', function(error, data) {
+          m.chai.expect(error).to.not.exist;
           m.chai.expect(data).to.deep.equal({ foo: 'bar' });
-        }).then(function() {
-          return storage.set('foo', { foo: 'baz' });
-        }).then(function() {
-          return storage.get('foo');
-        }).then(function(data) {
-          m.chai.expect(data).to.deep.equal({ foo: 'baz' });
-        }).nodeify(done);
+
+          storage.set('foo', { foo: 'baz' }, function(error) {
+            m.chai.expect(error).to.not.exist;
+
+            storage.get('foo', function(error, data) {
+              m.chai.expect(error).to.not.exist;
+              m.chai.expect(data).to.deep.equal({ foo: 'baz' });
+              done();
+            });
+          });
+        });
       });
 
       it('should not override the stored key if the passed data is invalid', function(done) {
-        storage.set('foo', _.noop).catch(function() {
-          return storage.get('foo');
-        }).then(function(data) {
-          m.chai.expect(data).to.deep.equal({ foo: 'bar' });
-        }).nodeify(done);
+        storage.set('foo', _.noop, function(error) {
+          m.chai.expect(error).to.be.an.instanceof(Error);
+
+          storage.get('foo', function(error, data) {
+            m.chai.expect(error).to.not.exist;
+            m.chai.expect(data).to.deep.equal({ foo: 'bar' });
+            done();
+          });
+        });
       });
 
     });
@@ -167,19 +220,31 @@ describe('Electron JSON Storage', function() {
 
   describe('.has()', function() {
 
-    it('should be rejected if no key', function() {
-      const promise = storage.has(null);
-      m.chai.expect(promise).to.be.rejectedWith('Missing key');
+    it('should yield an error if no key', function(done) {
+      storage.has(null, function(error, hasKey) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Missing key');
+        m.chai.expect(hasKey).to.not.exist;
+        done();
+      });
     });
 
-    it('should be rejected if key is not a string', function() {
-      const promise = storage.has(123);
-      m.chai.expect(promise).to.be.rejectedWith('Invalid key');
+    it('should yield an error if key is not a string', function(done) {
+      storage.has(123, function(error, hasKey) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Invalid key');
+        m.chai.expect(hasKey).to.not.exist;
+        done();
+      });
     });
 
-    it('should be rejected if key is a blank string', function() {
-      const promise = storage.has('    ');
-      m.chai.expect(promise).to.be.rejectedWith('Invalid key');
+    it('should yield an error if key is a blank string', function(done) {
+      storage.has('    ', function(error, hasKey) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Invalid key');
+        m.chai.expect(hasKey).to.not.exist;
+        done();
+      });
     });
 
     describe('given a stored key', function() {
@@ -188,19 +253,28 @@ describe('Electron JSON Storage', function() {
         storage.set('foo', { foo: 'bar' }, done);
       });
 
-      it('should eventually be true if the key exists', function() {
-        const promise = storage.has('foo');
-        m.chai.expect(promise).to.eventually.be.true;
+      it('should yield true if the key exists', function(done) {
+        storage.has('foo', function(error, hasKey) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(hasKey).to.equal(true);
+          done();
+        });
       });
 
-      it('should eventually be true if the key has a json extension', function() {
-        const promise = storage.has('foo.json');
-        m.chai.expect(promise).to.eventually.be.true;
+      it('should yield true if the key has a json extension', function(done) {
+        storage.has('foo.json', function(error, hasKey) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(hasKey).to.equal(true);
+          done();
+        });
       });
 
-      it('should eventually be true if the key does not exist', function() {
-        const promise = storage.has('hello');
-        m.chai.expect(promise).to.eventually.be.false;
+      it('should yield false if the key does not exist', function(done) {
+        storage.has('hello', function(error, hasKey) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(hasKey).to.equal(false);
+          done();
+        });
       });
 
     });
@@ -209,64 +283,100 @@ describe('Electron JSON Storage', function() {
 
   describe('.keys()', function() {
 
-    it('should return an empty array if no keys', function() {
-      const promise = storage.keys();
-      m.chai.expect(promise).to.become([]);
+    it('should yield an empty array if no keys', function(done) {
+      storage.keys(function(error, keys) {
+        m.chai.expect(error).to.not.exist;
+        m.chai.expect(keys).to.deep.equal([]);
+        done();
+      });
     });
 
-    it('should return a single key if there is one saved setting', function(done) {
-      storage.set('foo', 'bar').then(function() {
-        const promise = storage.keys();
-        m.chai.expect(promise).to.become([ 'foo' ]);
-      }).nodeify(done);
+    it('should yield a single key if there is one saved setting', function(done) {
+      storage.set('foo', 'bar', function(error) {
+        m.chai.expect(error).to.not.exist;
+
+        storage.keys(function(error, keys) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(keys).to.deep.equal([ 'foo' ]);
+          done();
+        });
+      });
     });
 
     it('should ignore the .json extension', function(done) {
-      storage.set('foo.json', 'bar').then(function() {
-        const promise = storage.keys();
-        m.chai.expect(promise).to.become([ 'foo' ]);
-      }).nodeify(done);
+      storage.set('foo.json', 'bar', function(error) {
+        m.chai.expect(error).to.not.exist;
+
+        storage.keys(function(error, keys) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(keys).to.deep.equal([ 'foo' ]);
+          done();
+        });
+      });
     });
 
     it('should only remove the .json extension', function(done) {
-      storage.set('foo.data', 'bar').then(function() {
-        const promise = storage.keys();
-        m.chai.expect(promise).to.become([ 'foo.data' ]);
-      }).nodeify(done);
+      storage.set('foo.data', 'bar', function(error) {
+        m.chai.expect(error).to.not.exist;
+
+        storage.keys(function(error, keys) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(keys).to.deep.equal([ 'foo.data' ]);
+          done();
+        });
+      });
     });
 
     it('should detect multiple saved settings', function(done) {
-      return Bluebird.all([
-        storage.set('one', 'foo'),
-        storage.set('two', 'bar'),
-        storage.set('three', 'baz')
-      ]).then(function() {
-        const promise = storage.keys();
-        m.chai.expect(promise).to.become([
-          'one',
-          'three',
-          'two'
-        ]);
-      }).nodeify(done);
+      storage.set('one', 'foo', function(error) {
+        m.chai.expect(error).to.not.exist;
+
+        storage.set('two', 'bar', function(error) {
+          m.chai.expect(error).to.not.exist;
+
+          storage.set('three', 'baz', function(error) {
+            m.chai.expect(error).to.not.exist;
+
+            storage.keys(function(error, keys) {
+              m.chai.expect(error).to.not.exist;
+              m.chai.expect(keys).to.deep.equal([
+                'one',
+                'three',
+                'two'
+              ]);
+              done();
+            });
+          });
+        });
+      });
     });
 
   });
 
   describe('.remove()', function() {
 
-    it('should be rejected if no key', function() {
-      const promise = storage.remove(null);
-      m.chai.expect(promise).to.be.rejectedWith('Missing key');
+    it('should yield an error if no key', function(done) {
+      storage.remove(null, function(error) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Missing key');
+        done();
+      });
     });
 
-    it('should be rejected if key is not a string', function() {
-      const promise = storage.remove(123);
-      m.chai.expect(promise).to.be.rejectedWith('Invalid key');
+    it('should yield an error if key is not a string', function(done) {
+      storage.remove(123, function(error) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Invalid key');
+        done();
+      });
     });
 
-    it('should be rejected if key is a blank string', function() {
-      const promise = storage.remove('    ');
-      m.chai.expect(promise).to.be.rejectedWith('Invalid key');
+    it('should yield an error if key is a blank string', function(done) {
+      storage.remove('     ', function(error) {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(error.message).to.equal('Invalid key');
+        done();
+      });
     });
 
     describe('given a stored key', function() {
@@ -276,25 +386,37 @@ describe('Electron JSON Storage', function() {
       });
 
       it('should be able to remove the key', function(done) {
-        storage.has('foo').then(function(hasKey) {
+        storage.has('foo', function(error, hasKey) {
+          m.chai.expect(error).to.not.exist;
           m.chai.expect(hasKey).to.be.true;
-          return storage.remove('foo');
-        }).then(function() {
-          return storage.has('foo');
-        }).then(function(hasKey) {
-          m.chai.expect(hasKey).to.be.false;
-        }).nodeify(done);
+
+          storage.remove('foo', function(error) {
+            m.chai.expect(error).to.not.exist;
+
+            storage.has('foo', function(error, hasKey) {
+              m.chai.expect(error).to.not.exist;
+              m.chai.expect(hasKey).to.be.false;
+              done()
+            });
+          });
+        });
       });
 
       it('should do nothing if the key does not exist', function(done) {
-        storage.has('bar').then(function(hasKey) {
+        storage.has('bar', function(error, hasKey) {
+          m.chai.expect(error).to.not.exist;
           m.chai.expect(hasKey).to.be.false;
-          return storage.remove('bar');
-        }).then(function() {
-          return storage.has('bar');
-        }).then(function(hasKey) {
-          m.chai.expect(hasKey).to.be.false;
-        }).nodeify(done);
+
+          storage.remove('bar', function(error) {
+            m.chai.expect(error).to.not.exist;
+
+            storage.has('bar', function(error, hasKey) {
+              m.chai.expect(error).to.not.exist;
+              m.chai.expect(hasKey).to.be.false;
+              done()
+            });
+          });
+        });
       });
 
     });
@@ -303,9 +425,11 @@ describe('Electron JSON Storage', function() {
 
   describe('.clear()', function() {
 
-    it('should not be rejected if no keys', function() {
-      const promise = storage.clear();
-      m.chai.expect(promise).to.eventually.be.undefined;
+    it('should not yield an error if no keys', function(done) {
+      storage.clear(function(error) {
+        m.chai.expect(error).to.not.exist;
+        done();
+      });
     });
 
     describe('given a stored key', function() {
@@ -315,39 +439,53 @@ describe('Electron JSON Storage', function() {
       });
 
       it('should clear the key', function(done) {
-        storage.has('foo').then(function(hasKey) {
+        storage.has('foo', function(error, hasKey) {
+          m.chai.expect(error).to.not.exist;
           m.chai.expect(hasKey).to.be.true;
-          return storage.clear();
-        }).then(function() {
-          return storage.has('foo');
-        }).then(function(hasKey) {
-          m.chai.expect(hasKey).to.be.false;
-        }).nodeify(done);
+
+          storage.clear(function(error) {
+            m.chai.expect(error).to.not.exist;
+
+            storage.has('foo', function(error, hasKey) {
+              m.chai.expect(error).to.not.exist;
+              m.chai.expect(hasKey).to.be.false;
+              done()
+            });
+          });
+        });
       });
 
       it('should not delete the user data directory', function(done) {
-        const isDirectory = function(dir) {
-          return fs.statAsync(dir).catch(function(error) {
-            if (error.code === 'ENOENT') {
-              return false;
+        const isDirectory = function(dir, callback) {
+          fs.stat(dir, function(error, stat) {
+            if (error) {
+              if (error.code === 'ENOENT') {
+                return callback(null, false);
+              }
+
+              return callback(error);
             }
 
-            throw error;
-          }).then(function(stats) {
-            return stats.isDirectory();
+            return callback(null, stat.isDirectory());
           });
         };
 
         const userDataPath = utils.getUserDataPath();
 
-        isDirectory(userDataPath).then(function(exists) {
+        isDirectory(userDataPath, function(error, exists) {
+          m.chai.expect(error).to.not.exist;
           m.chai.expect(exists).to.be.true;
-          return storage.clear();
-        }).then(function() {
-          return isDirectory(userDataPath);
-        }).then(function(exists) {
-          m.chai.expect(exists).to.be.true;
-        }).nodeify(done);
+
+          storage.clear(function(error) {
+            m.chai.expect(error).to.not.exist;
+
+            isDirectory(userDataPath, function(error, exists) {
+              m.chai.expect(error).to.not.exist;
+              m.chai.expect(exists).to.be.true;
+              done();
+            });
+          });
+        });
       });
 
     });
@@ -355,36 +493,62 @@ describe('Electron JSON Storage', function() {
     describe('given many stored keys', function() {
 
       beforeEach(function(done) {
-        Bluebird.all([
-          storage.set('foo', { name: 'foo' }),
-          storage.set('bar', { name: 'bar' }),
-          storage.set('baz', { name: 'baz' })
-        ]).nodeify(done);
+        storage.set('foo', { name: 'foo' }, function(error) {
+          if (error) {
+            return done(error);
+          }
+
+          storage.set('bar', { name: 'bar' }, function(error) {
+            if (error) {
+              return done(error);
+            }
+
+            storage.set('baz', { name: 'baz' }, function(error) {
+              if (error) {
+                return done(error);
+              }
+
+              done();
+            });
+          });
+        });
       });
 
       it('should clear all stored keys', function(done) {
-        Bluebird.props({
-          foo: storage.has('foo'),
-          bar: storage.has('bar'),
-          baz: storage.has('baz')
-        }).then(function(results) {
-          m.chai.expect(results.foo).to.be.true;
-          m.chai.expect(results.bar).to.be.true;
-          m.chai.expect(results.baz).to.be.true;
+        storage.has('foo', function(error, hasKey) {
+          m.chai.expect(error).to.not.exist;
+          m.chai.expect(hasKey).to.be.true;
 
-          return storage.clear();
-        }).then(function() {
-          return Bluebird.props({
-            foo: storage.has('foo'),
-            bar: storage.has('bar'),
-            baz: storage.has('baz')
+          storage.has('bar', function(error, hasKey) {
+            m.chai.expect(error).to.not.exist;
+            m.chai.expect(hasKey).to.be.true;
+
+            storage.has('baz', function(error, hasKey) {
+              m.chai.expect(error).to.not.exist;
+              m.chai.expect(hasKey).to.be.true;
+
+              storage.clear(function(error) {
+                m.chai.expect(error).to.not.exist;
+
+                storage.has('foo', function(error, hasKey) {
+                  m.chai.expect(error).to.not.exist;
+                  m.chai.expect(hasKey).to.be.false;
+
+                  storage.has('bar', function(error, hasKey) {
+                    m.chai.expect(error).to.not.exist;
+                    m.chai.expect(hasKey).to.be.false;
+
+                    storage.has('baz', function(error, hasKey) {
+                      m.chai.expect(error).to.not.exist;
+                      m.chai.expect(hasKey).to.be.false;
+                      done();
+                    });
+                  });
+                });
+              });
+            });
           });
-        }).then(function(results) {
-          m.chai.expect(results.foo).to.be.false;
-          m.chai.expect(results.bar).to.be.false;
-          m.chai.expect(results.baz).to.be.false;
-
-        }).nodeify(done);
+        });
       });
 
     });


### PR DESCRIPTION
Bluebird promises collide with ES6 Promises and break the module when
running in the renderer process.

This commit drops all support for promises, leaving the decision of
promisiying the module to the end user.

Fixes: https://github.com/jviotti/electron-json-storage/issues/5