### PR TITLE
Storage.get should not catch callback errors

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -81,13 +81,14 @@ exports.get = function(key, callback) {
       });
     },
     function(object, callback) {
+      var parseResult;
       try {
-        var parseResult = JSON.parse(object)
+        parseResult = JSON.parse(object);
       } catch (error) {
         callback(new Error('Invalid data'));
-        return
+        return;
       }
-      callback(null, parseResult)
+      callback(null, parseResult);
     }
   ], callback);
 };

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -82,10 +82,12 @@ exports.get = function(key, callback) {
     },
     function(object, callback) {
       try {
-        callback(null, JSON.parse(object));
+        var parseResult = JSON.parse(object)
       } catch (error) {
         callback(new Error('Invalid data'));
+        return
       }
+      callback(null, parseResult)
     }
   ], callback);
 };


### PR DESCRIPTION
Currently, if the callback provided to storage.get throws an exception, a couple of unexpected things happen.

1. Code expecting to catch thrown exceptions around the storage.get call will not receive them, and
2. The callback will be called twice. Once for the call after a successful `JSON.parse`, and again after any exception in the callback is caught.

This PR limits the try/catch to the JSON.parse call, and allows any callback exceptions to bubble up normally.
