### PR TITLE
Prevent errors when using reserved characters in Windows file names

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,5 +69,10 @@ exports.getFileName = function(key) {
   // if the key already contains it.
   const keyFileName = path.basename(key, '.json') + '.json';
 
-  return path.join(exports.getUserDataPath(), keyFileName);
+  // Prevent ENOENT and other similar errors when using
+  // reserved characters in Windows filenames.
+  // See: https://en.wikipedia.org/wiki/Filename#Reserved%5Fcharacters%5Fand%5Fwords
+  const escapedFileName = encodeURIComponent(keyFileName);
+
+  return path.join(exports.getUserDataPath(), escapedFileName);
 };

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -188,6 +188,22 @@ describe('Electron JSON Storage', function() {
       });
     });
 
+    it('should accept special characters as the key name', function(done) {
+      const key = 'foo?bar:baz';
+      async.waterfall([
+        function(callback) {
+          storage.set(key, { foo: 'baz' }, callback);
+        },
+        function(callback) {
+          storage.get(key, callback);
+        }
+      ], function(error, data) {
+        m.chai.expect(error).to.not.exist;
+        m.chai.expect(data).to.deep.equal({ foo: 'baz' });
+        done();
+      });
+    });
+
     describe('given an existing stored key', function() {
 
       beforeEach(function(done) {

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -86,6 +86,11 @@ describe('Utils', function() {
       m.chai.expect(path.isAbsolute(fileName)).to.be.true;
     });
 
+    it('should encode special characters', function() {
+      const fileName = utils.getFileName('foo?bar:baz');
+      m.chai.expect(path.basename(fileName)).to.equal('foo%3Fbar%3Abaz.json');
+    });
+
   });
 
 });


### PR DESCRIPTION
Fixes: https://github.com/jviotti/electron-json-storage/issues/26
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>