### PR TITLE
Resolving "Callback has already been called" issue

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -81,11 +81,13 @@ exports.get = function(key, callback) {
       });
     },
     function(object, callback) {
+      let objectJSON = {};
       try {
-        callback(null, JSON.parse(object));
+        objectJSON = JSON.parse(object);
       } catch (error) {
-        callback(new Error('Invalid data'));
+        return callback(new Error('Invalid data'));        
       }
+      return callback(null, objectJSON);
     }
   ], callback);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-json-storage",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Easily write and read user settings in Electron apps",
   "main": "lib/storage.js",
   "homepage": "https://github.com/jviotti/electron-json-storage",


### PR DESCRIPTION
Removed callback from try block and return if the catch block is entered.
This resolves and issue when the callback function throws and error and results in
the error "Callback has already been called".

@jviotti 