### PR TITLE
2.0.3

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -81,7 +81,7 @@ exports.get = function(key, callback) {
       });
     },
     function(object, callback) {
-      let objectJSON = {};
+      var objectJSON = {};
       try {
         objectJSON = JSON.parse(object);
       } catch (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-json-storage",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Easily write and read user settings in Electron apps",
   "main": "lib/storage.js",
   "homepage": "https://github.com/jviotti/electron-json-storage",


### PR DESCRIPTION
@jviotti I had to change the let to a var because the current version of uglify was having an issue transpiling the let command. Not sure why but this is a safe fix until uglify gets updated.