### PR TITLE
Create key filename directory if it doesn't exist

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -33,6 +33,7 @@ const async = require('async');
 const fs = require('fs');
 const exists = require('exists-file');
 const rimraf = require('rimraf');
+const mkdirp = require('mkdirp');
 const path = require('path');
 const utils = require('./utils');
 
@@ -187,7 +188,15 @@ exports.set = function(key, json, callback) {
         return callback(new Error('Invalid JSON data'));
       }
 
-      fs.writeFile(fileName, data, callback);
+      // Create the directory in case it doesn't exist yet
+      mkdirp(path.dirname(fileName), function(error) {
+        if (error) {
+          return callback(error);
+        }
+
+        fs.writeFile(fileName, data, callback);
+      });
+
     }
   ], callback);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,7 +28,6 @@ const _ = require('lodash');
 const path = require('path');
 const electron = require('electron');
 const app = electron.app || electron.remote.app;
-const userData = app.getPath('userData');
 
 /**
  * @summary Get user data directory path
@@ -41,7 +40,7 @@ const userData = app.getPath('userData');
  * console.log(userDataPath);
  */
 exports.getUserDataPath = function() {
-  return userData;
+  return app.getPath('userData');
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
     "electron-prebuilt": "^1.2.7",
     "jsdoc-to-markdown": "^1.1.1",
     "jshint": "^2.9.1",
-    "mochainon": "^1.0.0"
+    "mochainon": "^1.0.0",
+    "tmp": "0.0.31"
   },
   "dependencies": {
     "async": "^2.0.0",
     "exists-file": "^2.1.0",
     "lodash": "^4.0.1",
+    "mkdirp": "^0.5.1",
     "rimraf": "^2.5.1"
   }
 }


### PR DESCRIPTION
If the user sets a `userData` path that doesn't exist, `.set()` will
fail with an `ENOENT` error. As a solution, we use `mkdirp` to ensure
the dirname of the key's file name exists before writing to it.

Fixes: https://github.com/jviotti/electron-json-storage/issues/41
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>