### PR TITLE
Store data inside a "storage" directory in userData

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -250,14 +250,9 @@ exports.keys = function(callback) {
     async.asyncify(utils.getUserDataPath),
     fs.readdir,
     function(keys, callback) {
-      callback(null, _.chain(keys)
-        .reject(function(key) {
-          return _.includes([ 'GPUCache' ], key);
-        })
-        .map(function(key) {
-          return path.basename(key, '.json');
-        })
-        .value());
+      callback(null, _.map(keys, function(key) {
+        return path.basename(key, '.json');
+      }));
     }
   ], callback);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ const app = electron.app || electron.remote.app;
  * console.log(userDataPath);
  */
 exports.getUserDataPath = function() {
-  return app.getPath('userData');
+  return path.join(app.getPath('userData'), 'storage');
 };
 
 /**


### PR DESCRIPTION
We previously stores JSON files directly in userData, which would cause
`.keys()` to list irrelevant items, or `.clear()` to delete data other
than user settings.

This commit makes the module store data inside a `storage/` directory
inside `userData`.

THIS IS A BREAKING CHANGE:

- Add logic to your application to move every `.json` file inside
  `userData` to a `storage/` subdirectory.

Fixes: https://github.com/jviotti/electron-json-storage/issues/38
Fixes: https://github.com/jviotti/electron-json-storage/issues/28
Fixes: https://github.com/jviotti/electron-json-storage/issues/19
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>