### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
   "author": "Juan Cruz Viotti <jviottidc@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "electron-mocha": "^2.3.1",
+    "electron-mocha": "^3.3.0",
     "electron-prebuilt": "^1.2.7",
-    "jsdoc-to-markdown": "^1.1.1",
+    "jsdoc-to-markdown": "^2.0.1",
     "jshint": "^2.9.1",
     "mochainon": "^1.0.0",
     "tmp": "0.0.31"
   },
   "dependencies": {
     "async": "^2.0.0",
-    "exists-file": "^2.1.0",
+    "exists-file": "^3.0.0",
     "lodash": "^4.0.1",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.1"


### PR DESCRIPTION
- `electron-mocha` to v3.3.0
- `jsdoc-to-markdown` to v2.0.1
- `exists-file` to v3.0.0

None of the modules above introduced breaking changes that affect this
module.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>